### PR TITLE
Support latest two Go versions only

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,12 +9,14 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        go: [ '1.18', '1.19' ]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.14.4'
+          go-version: ${{ matrix.go }}
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/pdftables/go-pdftables-api
 
-go 1.14
+go 1.18


### PR DESCRIPTION
Go itself only provides continuing updates for the latest two versions.