### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,12 +14,12 @@ jobs:
         go: [ '1.18', '1.19' ]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build code
         run: |


### PR DESCRIPTION
Created in favour of #6 and #7.

Not sure why those Dependabot PRs don't give the "correct" (failing) output. If you remove the `grep`, they do give the "correct" output :man_shrugging: